### PR TITLE
fix: patch RapidJSON for GCC 16 compatibility

### DIFF
--- a/sources/json/document.h
+++ b/sources/json/document.h
@@ -316,7 +316,11 @@ struct GenericStringRef {
 
     GenericStringRef(const GenericStringRef& rhs) : s(rhs.s), length(rhs.length) {}
 
-    GenericStringRef& operator=(const GenericStringRef& rhs) { s = rhs.s; length = rhs.length; }
+    GenericStringRef& operator=(const GenericStringRef& rhs) { 
+    const_cast<const CharType*&>(s) = rhs.s; 
+    const_cast<SizeType&>(length) = rhs.length; 
+    return *this; 
+    }
 
     //! implicit conversion to plain CharType pointer
     operator const Ch *() const { return s; }

--- a/sources/rapidjson/document.h
+++ b/sources/rapidjson/document.h
@@ -316,7 +316,11 @@ struct GenericStringRef {
 
     GenericStringRef(const GenericStringRef& rhs) : s(rhs.s), length(rhs.length) {}
 
-    GenericStringRef& operator=(const GenericStringRef& rhs) { s = rhs.s; length = rhs.length; }
+    GenericStringRef& operator=(const GenericStringRef& rhs) { 
+        const_cast<const CharType*&>(s) = rhs.s; 
+        const_cast<SizeType&>(length) = rhs.length; 
+        return *this;
+    }
 
     //! implicit conversion to plain CharType pointer
     operator const Ch *() const { return s; }


### PR DESCRIPTION
Fixed read-only member assignment error in document.h by using const_cast.